### PR TITLE
Use a text/plain Blob as the browser beacon's payload & parse it on mdClose()

### DIFF
--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -352,7 +352,7 @@ def mdClose():
     res = requests.post(url, headers={
         'X-WOPI-Lock': json.dumps(wopilock),
         'X-WOPI-Override': 'PUT_RELATIVE',
-        'X-WOPI-SuggestedTarget': wopilock['filename'] + 'x'      # do not overwrite an existing file
+        'X-WOPI-SuggestedTarget': os.path.splitext(wopilock['filename'])[0] + '.zmd'    # do not overwrite an existing file
         }, data=bundlefile, verify=False)
 
   if res.status_code == http.client.OK:

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -56,9 +56,11 @@ class WB:
       window.addEventListener("unload", function close() {
         try {
           navigator.sendBeacon("%s/close",
-            { WOPISrc: '%s',
+            new Blob([JSON.stringify({
+              WOPISrc: '%s',
               access_token: '%s',
-              save: '%s'});
+              save: '%s'})], { type: 'text/plain' })
+          );
         }
         catch(err) {
           window.alert('Save to CERNBox failed: ' + err.message);
@@ -303,9 +305,10 @@ def mdSave(noteid):
 def mdClose():
   '''Close a MD doc by saving it back to the previously given WOPI Src and using the provided access token'''
   try:
-    acctok = flask.request.args['access_token']
-    wopiSrc = flask.request.args['WOPISrc']
-    if flask.request.args['save'] == 'False':
+    close_payload = flask.request.get_json(force=True)
+    acctok = close_payload['access_token']
+    wopiSrc = close_payload['WOPISrc']
+    if close_payload['save'] == 'False':
       WB.log.info('msg="Close called" save="False" client="%s" token="%s"' % \
                   (flask.request.remote_addr, acctok[-20:]))
       # TODO delete content from CodiMD - API is missing

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -56,9 +56,9 @@ class WB:
       window.addEventListener("unload", function close() {
         try {
           navigator.sendBeacon("%s/close",
-            {WOPISrc: '%s',
-             access_token: '%s',
-             save: '%s'});
+            { WOPISrc: '%s',
+              access_token: '%s',
+              save: '%s'});
         }
         catch(err) {
           window.alert('Save to CERNBox failed: ' + err.message);


### PR DESCRIPTION
Also fix the `X-WOPI-SuggestedTarget` header generation after https://github.com/cs3org/wopibridge/commit/376dfdcff75bba20122a49b8f30afdc1af6de72d.