### PR TITLE
Enable use of the CodiMD update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ This is a proof-of-concept WOPI bridge server, currently only targeting CodiMD, 
   * Files ending as `.zmd` are equally treated as zipped bundles and expanded to CodiMD
 
 ### Required CodiMD APIs
-* `/new`                    push a file to CodiMD
+* `/new`                    push a new file
 * `/<noteid>`               display a file
 * `/<noteid>/publish`       display a file in readonly mode
 * `/<noteid>/slide`         display a file in slide mode
-* `/<noteid>/download`      get a raw file to push it back
+* `/<noteid>/download`      get a raw file to store it back
 * `/uploadimage`            upload a new picture
 * `/uploads/upload_<hash>`  get an uploaded picture
+* `/api/notes/<noteid>`     update a file via PUT
 
 ### Required WOPI APIs
 * `GetFileInfo`: get all file metadata

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -25,12 +25,6 @@ import wopiclient as wopi
 class CodiMDFailure(Exception):
     '''A custom exception to represent a fatal failure when contacting CodiMD'''
 
-# a message to explain what happens when a lock is lost (could be passed from outside);
-# note the hyperlink is deliberately unquoted, as this is to be embedded in a JSON message
-# TODO to prevent this case from happening, we'd need a mechanism to persist the wopisrc-notehash mapping in CodiMD!
-SAVE_KB_LINK = 'File saved successfully, but a newer version might have been overwritten (see %s)' % \
-               '<a href=https://cern.service-now.com/service-portal?id=kb_article&n=KB0007127 target=_blank>KB0007127</a>'
-
 # a regexp for uploads, that have links like '/uploads/upload_542a360ddefe1e21ad1b8c85207d9365.*'
 upload_re = re.compile(r'\/uploads\/upload_\w{32}\.\w+')
 
@@ -259,10 +253,8 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
         wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
         log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' % \
                  (wopilock['filename'], isclose, acctok[-20:]))
-        # combine the responses and amend the message in case the file was relocked
-        return attresponse if attresponse else (
-            jsonify('File saved successfully' if wopilock['digest'] != 'relock' else SAVE_KB_LINK), \
-            http.client.OK)
+        # combine the responses
+        return attresponse if attresponse else (jsonify('File saved successfully'), http.client.OK)
 
     # on close, use saveas for either the new bundle, if this is the first time we have attachments,
     # or the single md file, if there are no more attachments.

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -16,7 +16,6 @@ import hashlib
 import urllib.parse
 import http.client
 from base64 import urlsafe_b64encode
-import hashlib
 import hmac
 import requests
 import wopiclient as wopi
@@ -179,8 +178,7 @@ def loadfromstorage(filemd, wopisrc, acctok):
     try:
         if not filemd['UserCanWrite']:
             # read-only case: push the doc to a newly generated note with a random docid
-            newparams = {'mode': 'locked'}   # this is an extended feature in CodiMD
-            res = requests.post(codimdurl + '/new', data=mddoc, allow_redirects=False, params=newparams,
+            res = requests.post(codimdurl + '/new', data=mddoc, allow_redirects=False, params={'mode': 'locked'},
                                 headers={'Content-Type': 'text/markdown'}, verify=not skipsslverify)
             if res.status_code != http.client.FOUND:
                 log.error('msg="Unable to push read-only document to CodiMD" token="%s" response="%d"' % \
@@ -205,7 +203,6 @@ def loadfromstorage(filemd, wopisrc, acctok):
                 log.error('msg="Unable to push document to CodiMD" token="%s" response="%d"' % \
                           (acctok[-20:], res.status_code))
                 raise CodiMDFailure
-            log.debug('msg="PUT returned from CodiMD" content="%s"' % res.content)
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to CodiMD" exception="%s"' % e)
         raise CodiMDFailure

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -109,7 +109,7 @@ def _fetchfromcodimd(wopilock, acctok):
     try:
         res = requests.get(codimdurl + wopilock['docid'] + '/download', verify=not skipsslverify)
         if res.status_code != http.client.OK:
-            log.error('msg="Unable to fetch document from CodiMD" token="%s" response="%d: %s"' % \
+            log.error('msg="Unable to fetch document from CodiMD" token="%s" response="%d: %s"' %
                       (acctok[-20:], res.status_code, res.content))
             raise CodiMDFailure
         return res.content
@@ -127,7 +127,7 @@ def _saveas(wopisrc, acctok, wopilock, targetname, content):
                     }
     res = wopi.request(wopisrc, acctok, 'POST', headers=putrelheaders, contents=content)
     if res.status_code != http.client.OK:
-        log.warning('msg="Calling WOPI PutRelative failed" url="%s" response="%s" reason="%s"' % \
+        log.warning('msg="Calling WOPI PutRelative failed" url="%s" response="%s" reason="%s"' %
                     (wopisrc, res.status_code, res.headers.get('X-WOPI-LockFailureReason')))
         # if res.status_code != http.client.CONFLICT: TODO need to save the file on a local storage for later recovery
         return jsonify('Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason')), res.status_code
@@ -138,12 +138,12 @@ def _saveas(wopisrc, acctok, wopilock, targetname, content):
     # unlock and delete original file
     res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock), 'X-Wopi-Override': 'UNLOCK'})
     if res.status_code != http.client.OK:
-        log.warning('msg="Failed to unlock the previous file" token="%s" response="%d"' % \
+        log.warning('msg="Failed to unlock the previous file" token="%s" response="%d"' %
                     (acctok[-20:], res.status_code))
     else:
         res = wopi.request(wopisrc, acctok, 'POST', headers={'X-Wopi-Override': 'DELETE'})
         if res.status_code != http.client.OK:
-            log.warning('msg="Failed to delete the previous file" token="%s" response="%d"' % \
+            log.warning('msg="Failed to delete the previous file" token="%s" response="%d"' %
                         (acctok[-20:], res.status_code))
         else:
             log.info('msg="Previous file unlocked and removed successfully" token="%s"' % acctok[-20:])
@@ -181,7 +181,7 @@ def loadfromstorage(filemd, wopisrc, acctok):
             res = requests.post(codimdurl + '/new', data=mddoc, allow_redirects=False, params={'mode': 'locked'},
                                 headers={'Content-Type': 'text/markdown'}, verify=not skipsslverify)
             if res.status_code != http.client.FOUND:
-                log.error('msg="Unable to push read-only document to CodiMD" token="%s" response="%d"' % \
+                log.error('msg="Unable to push read-only document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
                 raise CodiMDFailure
             notehash = urllib.parse.urlsplit(res.next.url).path.split('/')[-1]
@@ -192,7 +192,7 @@ def loadfromstorage(filemd, wopisrc, acctok):
             notehash = urlsafe_b64encode(dig).decode()[:-1]
             res = requests.get(codimdurl + '/' + notehash, verify=not skipsslverify)
             if res.status_code != http.client.OK:
-                log.error('msg="Unable to GET notehash from CodiMD" token="%s" response="%d"' % \
+                log.error('msg="Unable to GET notehash from CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
                 raise CodiMDFailure
             log.debug('msg="Got note hash from CodiMD" url="/%s"' % notehash)
@@ -200,7 +200,7 @@ def loadfromstorage(filemd, wopisrc, acctok):
             res = requests.put(codimdurl + '/api/notes/' + notehash,
                                json={'content': mddoc.decode()}, verify=not skipsslverify)
             if res.status_code != http.client.OK:
-                log.error('msg="Unable to push document to CodiMD" token="%s" response="%d"' % \
+                log.error('msg="Unable to push document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
                 raise CodiMDFailure
     except requests.exceptions.ConnectionError as e:
@@ -248,7 +248,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
             return jsonify('Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason')), res.status_code
         # and refresh the WOPI lock
         wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
-        log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' % \
+        log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
                  (wopilock['filename'], isclose, acctok[-20:]))
         # combine the responses
         return attresponse if attresponse else (jsonify('File saved successfully'), http.client.OK)

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -178,8 +178,11 @@ def loadfromstorage(filemd, wopisrc, acctok):
     try:
         if not filemd['UserCanWrite']:
             # read-only case: push the doc to a newly generated note with a random docid
-            res = requests.post(codimdurl + '/new', data=mddoc, allow_redirects=False, params={'mode': 'locked'},
-                                headers={'Content-Type': 'text/markdown'}, verify=not skipsslverify)
+            res = requests.post(codimdurl + '/new', data=mddoc,
+                                allow_redirects=False,
+                                params={'mode': 'locked'},
+                                headers={'Content-Type': 'text/markdown'},
+                                verify=not skipsslverify)
             if res.status_code != http.client.FOUND:
                 log.error('msg="Unable to push read-only document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
@@ -192,13 +195,14 @@ def loadfromstorage(filemd, wopisrc, acctok):
             notehash = urlsafe_b64encode(dig).decode()[:-1]
             res = requests.get(codimdurl + '/' + notehash, verify=not skipsslverify)
             if res.status_code != http.client.OK:
-                log.error('msg="Unable to GET notehash from CodiMD" token="%s" response="%d"' %
+                log.error('msg="Unable to GET note hash from CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
                 raise CodiMDFailure
             log.debug('msg="Got note hash from CodiMD" url="/%s"' % notehash)
             # push the document to CodiMD with the update API
             res = requests.put(codimdurl + '/api/notes/' + notehash,
-                               json={'content': mddoc.decode()}, verify=not skipsslverify)
+                               json={'content': mddoc.decode()},
+                               verify=not skipsslverify)
             if res.status_code != http.client.OK:
                 log.error('msg="Unable to push document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
@@ -207,9 +211,8 @@ def loadfromstorage(filemd, wopisrc, acctok):
         log.error('msg="Exception raised attempting to connect to CodiMD" exception="%s"' % e)
         raise CodiMDFailure
     # we got the hash of the document just created as a redirected URL, generate a WOPI lock structure
-    wopilock = wopi.generatelock(notehash, \
-                                 filemd, h.hexdigest(), \
-                                 'slide' if _isslides(mddoc) else 'md', \
+    wopilock = wopi.generatelock(notehash, filemd, h.hexdigest(),
+                                 'slide' if _isslides(mddoc) else 'md',
                                  acctok, False)
     log.info('msg="Pushed document to CodiMD" url="%s" token="%s"' % (wopilock['docid'], acctok[-20:]))
     return wopilock

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -38,7 +38,7 @@ hashsecret = None
 def jsonify(msg):
     '''One-liner to consistently json-ify a given message'''
     # a delay = 0 means the user has to click on it to dismiss it, good for longer messages
-    return '{"message": "%s", "delay": "%.1f"}' % (msg, 0 if len(msg) > 90 else 1 + len(msg) * 3.0 / 70)
+    return '{"message": "%s", "delay": "%.1f"}' % (msg, 0 if len(msg) > 60 else 0.5 + len(msg)/20)
 
 
 def _getattachments(mddoc, docfilename, forcezip=False):
@@ -226,7 +226,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
                  (isclose, codimdurl + wopilock['docid'], acctok[-20:]))
         mddoc = _fetchfromcodimd(wopilock, acctok)
     except CodiMDFailure:
-        return jsonify('Failed to fetch document from CodiMD'), http.client.INTERNAL_SERVER_ERROR
+        return jsonify('Could not save file, failed to fetch document from CodiMD'), http.client.INTERNAL_SERVER_ERROR
 
     if isclose and wopilock['digest'] != 'dirty':
         # so far the file was not touched and we are about to close: before forcing a put let's validate the contents

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -398,9 +398,9 @@ class SaveThread(threading.Thread):
             try:
                 wopilock = wopi.getlock(wopisrc, openfile['acctok']) if not wopilock else wopilock
                 # this will force a close in the cleanup step
-                wopilock['toclose'] = {t: True for t in wopilock['toclose']}
+                openfile['toclose'] = {t: True for t in openfile['toclose']}
                 WB.log.info('msg="SaveThread: force-closing document" lastsavetime="%s" toclosetokens="%s"' %
-                            (openfile['lastsave'], wopilock['toclose']))
+                            (openfile['lastsave'], openfile['toclose']))
             except wopi.InvalidLock:
                 # lock is gone, just cleanup our metadata
                 WB.log.warning('msg="SaveThread: cleaning up metadata, detected missed close event" url="%s"' % wopisrc)

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -98,7 +98,7 @@ class WB:
             try:
                 cls.saveinterval = int(os.environ.get('APP_SAVE_INTERVAL'))
             except TypeError:
-                cls.saveinterval = 120
+                cls.saveinterval = 200
             try:
                 cls.saveinterval = int(os.environ.get('APP_UNLOCK_INTERVAL'))
             except TypeError:

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -398,12 +398,12 @@ class SaveThread(threading.Thread):
             try:
                 wopilock = wopi.getlock(wopisrc, openfile['acctok']) if not wopilock else wopilock
                 # this will force a close in the cleanup step
-                WB.log.info('msg="SaveThread: force-closing document" lastsavetime="%s" token="%s"' %
-                            (openfile['lastsave'], openfile['acctok'][-20:]))
                 wopilock['toclose'] = {t: True for t in wopilock['toclose']}
+                WB.log.info('msg="SaveThread: force-closing document" lastsavetime="%s" toclosetokens="%s"' %
+                            (openfile['lastsave'], wopilock['toclose']))
             except wopi.InvalidLock:
                 # lock is gone, just cleanup our metadata
-                WB.log.warning('msg="SaveThread: cleaning up metadata, detected missed close events" url="%s"' % wopisrc)
+                WB.log.warning('msg="SaveThread: cleaning up metadata, detected missed close event" url="%s"' % wopisrc)
                 del WB.openfiles[wopisrc]
         return wopilock
 

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -189,7 +189,7 @@ def appopen():
     # WOPI GetFileInfo
     res = wopi.request(wopisrc, acctok, 'GET')
     if res.status_code != http.client.OK:
-        WB.log.warning('msg="Open: unable to fetch file WOPI metadata" error="%s" response="%d"' % \
+        WB.log.warning('msg="Open: unable to fetch file WOPI metadata" error="%s" response="%d"' %
                        (res.content, res.status_code))
         return _guireturn('Invalid WOPI context'), http.client.NOT_FOUND
     filemd = res.json()
@@ -275,7 +275,8 @@ def appsave():
         acctok = meta[meta.index('?t=')+3:]
         isclose = flask.request.args.get('close') == 'true'
         docid = flask.request.args.get('id')
-        WB.log.info('msg="Save: requested action" isclose="%s" docid="%s" token="%s"' % (isclose, docid, acctok[-20:]))
+        WB.log.info('msg="Save: requested action" isclose="%s" docid="%s" wopisrc="%s" token="%s"' %
+                    (isclose, docid, wopisrc, acctok[-20:]))
     except (KeyError, ValueError) as e:
         WB.log.error('msg="Save: malformed or missing metadata" client="%s" headers="%s" exception="%s" error="%s"' %
                      (flask.request.remote_addr, flask.request.headers, type(e), e))
@@ -289,7 +290,7 @@ def appsave():
             WB.openfiles[wopisrc]['tosave'] = True
             WB.openfiles[wopisrc]['toclose'][acctok[-20:]] = isclose
         else:
-            WB.log.info('msg="Save: repopulating missing metadata" token="%s"' % acctok[-20:])
+            WB.log.info('msg="Save: repopulating missing metadata" wopisrc="%s" token="%s"' % (wopisrc, acctok[-20:]))
             WB.openfiles[wopisrc] = {'acctok': acctok, 'tosave': True,
                                      'lastsave': int(time.time() - WB.saveinterval),
                                      'toclose': {acctok[-20:]: isclose},
@@ -367,7 +368,7 @@ class SaveThread(threading.Thread):
             try:
                 wopilock = wopi.getlock(wopisrc, openfile['acctok'])
             except wopi.InvalidLock:
-                WB.log.info('msg="SaveThread: attempting to relock file" token="%s" docid="%s"' % \
+                WB.log.info('msg="SaveThread: attempting to relock file" token="%s" docid="%s"' %
                             (openfile['acctok'][-20:], openfile['docid']))
                 try:
                     wopilock = WB.saveresponses[wopisrc] = wopi.relock(
@@ -381,7 +382,7 @@ class SaveThread(threading.Thread):
                     openfile['tosave'] = False
                     openfile['toclose'] = {'invalid-lock': True}
                     return None
-            WB.log.info('msg="SaveThread: saving file" token="%s" docid="%s"' % \
+            WB.log.info('msg="SaveThread: saving file" token="%s" docid="%s"' %
                         (openfile['acctok'][-20:], openfile['docid']))
             WB.saveresponses[wopisrc] = codimd.savetostorage(
                 wopisrc, openfile['acctok'], _intersection(openfile['toclose']), wopilock)

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -103,6 +103,7 @@ class WB:
             # init modules
             codimd.log = wopi.log = cls.log
             codimd.skipsslverify = wopi.skipsslverify = cls.skipsslverify
+            codimd.hashsecret = b'TODOsecret'
 
             # start the thread to perform async save operations
             cls.savethread = SaveThread()

--- a/poc_src/wopiclient.py
+++ b/poc_src/wopiclient.py
@@ -109,11 +109,12 @@ def relock(wopisrc, acctok, docid, isclose):
     filemd = res.json()
 
     # lock the file again: we assume we are alone as the previous lock had been released
-    wopilock = generatelock(docid, filemd, 'relock', 'md', acctok, isclose)
+    wopilock = generatelock(docid, filemd, 'dirty', 'md', acctok, isclose)
     res = request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock), 'X-Wopi-Override': 'LOCK'})
     if res.status_code != http.client.OK:
         log.warning('msg="Failed to relock the file" response="%d" token="%s" reason="%s"' % (
             res.status_code, acctok[-20:], res.headers.get('X-WOPI-LockFailureReason')))
         raise InvalidLock('Failed to relock the file on save, please refresh this page')
-    # relock was successful, return it
+    # relock was successful, return lock: along with noteids univocally associated to files (WOPISrc's),
+    # we are sure no other updates could have been missed
     return wopilock


### PR DESCRIPTION
The recently added update API allows to push content to a given document identified by a noteid.

Together with the ability to "reserve" an arbitrary noteid via GET when `allowFreeURL` is set to true, this allows the useful feature to uniquely bind EFSS files to CodiMD documents, with the deterministic creation of a noteid as a function of the `WOPISrc` and a configured secret.

This PR implements this change and some related simplifications, given that we can unlock and relock the document knowing it will always be the same.