### PR TITLE
Enable pluggable applications and add initial support for Etherpad

### DIFF
--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -39,12 +39,12 @@ def init(env, apipath):
     global appexturl
     global apikey
     appexturl = env.get('CODIMD_EXT_URL')
+    if not appexturl:
+        raise ValueError("Missing CODIMD_EXT_URL env var")
     appurl = env.get('CODIMD_URL')
     if not appurl:
         # defaults to the external
         appurl = appexturl
-    if not appurl:
-        raise ValueError("Missing CODIMD_EXT_URL env var")
     with open(apipath + 'codimd_apikey') as f:
         apikey = f.readline().strip('\n')
 

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -15,25 +15,38 @@ import json
 import hashlib
 import urllib.parse as urlparse
 import http.client
-from base64 import urlsafe_b64encode
-import hmac
 import requests
 import wopiclient as wopi
 
 
-class CodiMDFailure(Exception):
+class AppFailure(Exception):
     '''A custom exception to represent a fatal failure when contacting CodiMD'''
 
 # a regexp for uploads, that have links like '/uploads/upload_542a360ddefe1e21ad1b8c85207d9365.*'
 upload_re = re.compile(r'\/uploads\/upload_\w{32}\.\w+')
 
-# initialized by the main class
-log = None
-codimdurl = None
-codimdexturl = None
-skipsslverify = None
-hashsecret = None
+# initialized by the main class or by the init method
+appurl = None
+appexturl = None
 apikey = None
+log = None
+skipsslverify = None
+
+
+def init(env, apipath):
+    '''Initialize global vars from the environment'''
+    global appurl
+    global appexturl
+    global apikey
+    appexturl = env.get('CODIMD_EXT_URL')
+    appurl = env.get('CODIMD_URL')
+    if not appurl:
+        # defaults to the external
+        appurl = appexturl
+    if not appurl:
+        raise ValueError("Missing CODIMD_EXT_URL env var")
+    with open(apipath + 'codimd_apikey') as f:
+        apikey = f.readline().strip('\n')
 
 
 def jsonify(msg):
@@ -42,13 +55,25 @@ def jsonify(msg):
     return '{"message": "%s", "delay": "%.1f"}' % (msg, 0 if len(msg) > 60 else 0.5 + len(msg)/20)
 
 
+def getredirecturl(isreadwrite, wopisrc, acctok, wopilock, displayname):
+    '''Return a valid URL to the app for the given WOPI context'''
+    if isreadwrite:
+        url = appexturl + wopilock['docid'] + '?metadata=' + \
+              urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + '&'
+    else:
+        # read-only mode: in this case redirect to publish mode or normal view
+        # to quickly jump in slide mode depending on the content
+        url = appexturl + wopilock['docid'] + ('/publish?' if wopilock['app'] != 'mds' else '?')
+    # in all cases append the display name and the API key
+    return url + 'apikey=' + apikey + '&displayName=' + displayname
+
+
 # Cloud storage to CodiMD
 ##########################
 
 def _unzipattachments(inputbuf):
     '''Unzip the given input buffer uploading the content to CodiMD and return the contained .md file'''
-    inputzip = zipfile.ZipFile(io.BytesIO(
-        inputbuf), compression=zipfile.ZIP_STORED)
+    inputzip = zipfile.ZipFile(io.BytesIO(inputbuf), compression=zipfile.ZIP_STORED)
     mddoc = None
     for zipinfo in inputzip.infolist():
         fname = zipinfo.filename
@@ -57,7 +82,7 @@ def _unzipattachments(inputbuf):
             mddoc = inputzip.read(zipinfo)
         else:
             # first check if the file already exists in CodiMD:
-            res = requests.head(codimdurl + '/uploads/' + fname, verify=not skipsslverify)
+            res = requests.head(appurl + '/uploads/' + fname, verify=not skipsslverify)
             if res.status_code == http.client.OK and int(res.headers['Content-Length']) == zipinfo.file_size:
                 # yes (assume that hashed filename AND size matching is a good enough content match!)
                 log.debug('msg="Skipped existing attachment" filename="%s"' % fname)
@@ -72,7 +97,7 @@ def _unzipattachments(inputbuf):
                 mddoc = mddoc.replace(zipinfo.filename, fname)
             # OK, let's upload
             log.debug('msg="Pushing attachment" filename="%s"' % fname)
-            res = requests.post(codimdurl + '/uploadimage', params={'generateFilename': 'false'},
+            res = requests.post(appurl + '/uploadimage', params={'generateFilename': 'false'},
                                 files={'image': (fname, inputzip.read(zipinfo))}, verify=not skipsslverify)
             if res.status_code != http.client.OK:
                 log.error('msg="Failed to push included file" filename="%s" httpcode="%d"' % (fname, res.status_code))
@@ -85,33 +110,20 @@ def _isslides(doc):
 
 
 def _fetchfromcodimd(wopilock, acctok):
-    '''Fetch a given document from from CodiMD, raise CodiMDFailure in case of errors'''
+    '''Fetch a given document from from CodiMD, raise AppFailure in case of errors'''
     try:
-        res = requests.get(codimdurl + wopilock['docid'] + '/download', verify=not skipsslverify)
+        res = requests.get(appurl + wopilock['docid'] + '/download', verify=not skipsslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Unable to fetch document from CodiMD" token="%s" response="%d: %s"' %
                       (acctok[-20:], res.status_code, res.content))
-            raise CodiMDFailure
+            raise AppFailure
         return res.content
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to CodiMD" exception="%s"' % e)
-        raise CodiMDFailure
+        raise AppFailure
 
 
-def checkredirect(wopilock, acctok):
-    '''Check if the target docid is real or is a redirect, and amend the wopilock structure in such case'''
-    res = requests.head(codimdurl + wopilock['docid'],
-                        params={'apikey': apikey},
-                        verify=not skipsslverify)
-    if res.status_code == http.client.FOUND:
-        notehash = urlparse.urlsplit(res.next.url).path.split('/')[-1]
-        log.info('msg="Document got aliased in CodiMD" olddocid="%s" docid="%s" token="%s"' %
-                 (wopilock['docid'], notehash, acctok[-20:]))
-        wopilock['docid'] = '/' + notehash
-    return wopilock
-
-
-def loadfromstorage(filemd, wopisrc, acctok):
+def loadfromstorage(filemd, wopisrc, acctok, docid=None):
     '''Copy document from storage to CodiMD'''
     # WOPI GetFile
     res = wopi.request(wopisrc, acctok, 'GET', contents=True)
@@ -131,7 +143,7 @@ def loadfromstorage(filemd, wopisrc, acctok):
     try:
         if not filemd['UserCanWrite']:
             # read-only case: push the doc to a newly generated note with a random docid
-            res = requests.post(codimdurl + '/new', data=mddoc,
+            res = requests.post(appurl + '/new', data=mddoc,
                                 allow_redirects=False,
                                 params={'mode': 'locked'},
                                 headers={'Content-Type': 'text/markdown'},
@@ -139,26 +151,24 @@ def loadfromstorage(filemd, wopisrc, acctok):
             if res.status_code != http.client.FOUND:
                 log.error('msg="Unable to push read-only document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
-                raise CodiMDFailure
-            notehash = urlparse.urlsplit(res.next.url).path.split('/')[-1]
-            log.info('msg="Pushed read-only document to CodiMD" docid="%s" token="%s"' % (notehash, acctok[-20:]))
+                raise AppFailure
+            docid = urlparse.urlsplit(res.next.url).path.split('/')[-1]
+            log.info('msg="Pushed read-only document to CodiMD" docid="%s" token="%s"' % (docid, acctok[-20:]))
         else:
-            # generate a deterministic note hash and reserve it in CodiMD via a HEAD request
-            dig = hmac.new(hashsecret, msg=wopisrc.split('/')[-1].encode(), digestmod=hashlib.sha1).digest()
-            notehash = urlsafe_b64encode(dig).decode()[:-1]
-            res = requests.head(codimdurl + '/' + notehash,
+            # reserve the given docid in CodiMD via a HEAD request
+            res = requests.head(appurl + '/' + docid,
                                 params={'apikey': apikey},
                                 verify=not skipsslverify)
-            if res.status_code != http.client.OK:
+            if res.status_code not in (http.client.OK, http.client.FOUND):
                 log.error('msg="Unable to reserve note hash in CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
-                raise CodiMDFailure
-            log.debug('msg="Got note hash from CodiMD" docid="%s"' % notehash)
+                raise AppFailure
+            log.debug('msg="Got note hash from CodiMD" docid="%s"' % docid)
             # push the document to CodiMD with the update API
             # TODO in the future we could swap the logic: attempt to push content, and on 404 use a HEAD
-            # request to reserve the notehash + do the push again. In most cases the note will be there
+            # request to reserve the docid + do the push again. In most cases the note will be there
             # thus we would avoid the HEAD call.
-            res = requests.put(codimdurl + '/api/notes/' + notehash,
+            res = requests.put(appurl + '/api/notes/' + docid,
                                params={'apikey': apikey},    # possibly required in the future
                                json={'content': mddoc.decode()},
                                verify=not skipsslverify)
@@ -168,17 +178,22 @@ def loadfromstorage(filemd, wopisrc, acctok):
             elif res.status_code != http.client.OK:
                 log.error('msg="Unable to push document to CodiMD" token="%s" response="%d"' %
                           (acctok[-20:], res.status_code))
-                raise CodiMDFailure
-            else:
-                log.info('msg="Pushed document to CodiMD" docid="%s" token="%s"' % (notehash, acctok[-20:]))
+                raise AppFailure
+            # check again if the target docid is real or is a redirect
+            res = requests.head(appurl + '/' + docid,
+                                params={'apikey': apikey},
+                                verify=not skipsslverify)
+            if res.status_code == http.client.FOUND:
+                newdocid = urlparse.urlsplit(res.next.url).path.split('/')[-1]
+                log.info('msg="Document got aliased in CodiMD" olddocid="%s" docid="%s" token="%s"' %
+                        (docid, newdocid, acctok[-20:]))
+                docid = newdocid
+            log.info('msg="Pushed document to CodiMD" docid="%s" token="%s"' % (docid, acctok[-20:]))
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to CodiMD" exception="%s"' % e)
-        raise CodiMDFailure
-    # we got the hash of the document just created as a redirected URL, generate a WOPI lock structure
-    wopilock = wopi.generatelock(notehash, filemd, h.hexdigest(),
-                                 'slide' if _isslides(mddoc) else 'md',
-                                 acctok, False)
-    return wopilock
+        raise AppFailure
+    # generate and return a WOPI lock structure for this document
+    return wopi.generatelock(docid, filemd, h.hexdigest(), 'mds' if _isslides(mddoc) else 'md', acctok, False)
 
 
 # CodiMD to cloud storage
@@ -190,7 +205,7 @@ def _getattachments(mddoc, docfilename, forcezip=False):
     response = None
     for attachment in upload_re.findall(mddoc):
         log.debug('msg="Fetching attachment" url="%s"' % attachment)
-        res = requests.get(codimdurl + attachment, verify=not skipsslverify)
+        res = requests.get(appurl + attachment, verify=not skipsslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Failed to fetch included file, skipping" path="%s" response="%d"' % (
                 attachment, res.status_code))
@@ -208,46 +223,14 @@ def _getattachments(mddoc, docfilename, forcezip=False):
     return zip_buffer.getvalue(), response
 
 
-def _saveas(wopisrc, acctok, wopilock, targetname, content):
-    '''Save a given document with an alternate name by using WOPI PutRelative'''
-    putrelheaders = {'X-WOPI-Lock': json.dumps(wopilock),
-                     'X-WOPI-Override': 'PUT_RELATIVE',
-                     # SuggestedTarget to not overwrite a possibly existing file
-                     'X-WOPI-SuggestedTarget': targetname
-                    }
-    res = wopi.request(wopisrc, acctok, 'POST', headers=putrelheaders, contents=content)
-    reply = wopi.handleputfile('PutRelative', wopisrc, res)
-    if reply:
-        return jsonify(reply), http.client.INTERNAL_SERVER_ERROR
-
-    # use the new file's metadata from PutRelative to remove the previous file: we can do that only on close
-    # because we need to keep using the current wopisrc/acctok until the session is alive in CodiMD
-    newname = res.json()['Name']
-    # unlock and delete original file
-    res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock), 'X-Wopi-Override': 'UNLOCK'})
-    if res.status_code != http.client.OK:
-        log.warning('msg="Failed to unlock the previous file" token="%s" response="%d"' %
-                    (acctok[-20:], res.status_code))
-    else:
-        res = wopi.request(wopisrc, acctok, 'POST', headers={'X-Wopi-Override': 'DELETE'})
-        if res.status_code != http.client.OK:
-            log.warning('msg="Failed to delete the previous file" token="%s" response="%d"' %
-                        (acctok[-20:], res.status_code))
-        else:
-            log.info('msg="Previous file unlocked and removed successfully" token="%s"' % acctok[-20:])
-
-    log.info('msg="Final save completed" filename"%s" token="%s"' % (newname, acctok[-20:]))
-    return jsonify('File saved successfully'), http.client.OK
-
-
 def savetostorage(wopisrc, acctok, isclose, wopilock):
     '''Copy document from CodiMD back to storage'''
     # get document from CodiMD
     try:
-        log.info('msg="Fetching file from CodiMD" isclose="%s" codimdurl="%s" token="%s"' %
-                 (isclose, codimdurl + wopilock['docid'], acctok[-20:]))
+        log.info('msg="Fetching file from CodiMD" isclose="%s" appurl="%s" token="%s"' %
+                 (isclose, appurl + wopilock['docid'], acctok[-20:]))
         mddoc = _fetchfromcodimd(wopilock, acctok)
-    except CodiMDFailure:
+    except AppFailure:
         return jsonify('Could not save file, failed to fetch document from CodiMD'), http.client.INTERNAL_SERVER_ERROR
 
     if wopilock['digest'] != 'dirty':
@@ -278,5 +261,6 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
 
     # on close, use saveas for either the new bundle, if this is the first time we have attachments,
     # or the single md file, if there are no more attachments.
-    return _saveas(wopisrc, acctok, wopilock, os.path.splitext(wopilock['filename'])[0] + ('.zmd' if bundlefile else '.md'),
-                   bundlefile if bundlefile else mddoc)
+    msg, rc = wopi.saveas(wopisrc, acctok, wopilock, os.path.splitext(wopilock['filename'])[0] + ('.zmd' if bundlefile else '.md'),
+                          bundlefile if bundlefile else mddoc)
+    return jsonify(msg), rc

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -115,7 +115,7 @@ def _fetchfromcodimd(wopilock, acctok):
         res = requests.get(appurl + wopilock['docid'] + '/download', verify=not skipsslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Unable to fetch document from CodiMD" token="%s" response="%d: %s"' %
-                      (acctok[-20:], res.status_code, res.content))
+                      (acctok[-20:], res.status_code, res.content.decode()))
             raise AppFailure
         return res.content
     except requests.exceptions.ConnectionError as e:

--- a/poc_src/codimd.py
+++ b/poc_src/codimd.py
@@ -123,7 +123,7 @@ def _fetchfromcodimd(wopilock, acctok):
         raise AppFailure
 
 
-def loadfromstorage(filemd, wopisrc, acctok, docid=None):
+def loadfromstorage(filemd, wopisrc, acctok, docid):
     '''Copy document from storage to CodiMD'''
     # WOPI GetFile
     res = wopi.request(wopisrc, acctok, 'GET', contents=True)
@@ -141,7 +141,7 @@ def loadfromstorage(filemd, wopisrc, acctok, docid=None):
     h = hashlib.sha1()
     h.update(mddoc)
     try:
-        if not filemd['UserCanWrite']:
+        if not docid:
             # read-only case: push the doc to a newly generated note with a random docid
             res = requests.post(appurl + '/new', data=mddoc,
                                 allow_redirects=False,

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -55,24 +55,25 @@ def jsonify(msg):
     return '{"message": "%s"}' % msg
 
 
-def _padid(padname):
-    '''One-liner to generate a padID from a padName'''
-    return groupid + '$' + padname
-
-
 def _apicall(method, params, data=None, acctok=None, raiseonnonzerocode=True):
     '''Generic method to call the Etherpad REST API'''
     params['apikey'] = apikey
-    res = requests.post(appurl + '/api/1/' + method, params=params, data=data, verify=not skipsslverify)
-    if res.status_code != http.client.OK:
-        log.error('msg="Failed to call Etherpad" method="%s" token="%s" response="%d: %s"' %
-                    (method, acctok[-20:] if acctok else 'N/A', res.status_code, res.content.decode()))
+    try:
+        res = requests.post(appurl + '/api/1/' + method, params=params, data=data, verify=not skipsslverify)
+        if res.status_code != http.client.OK:
+            log.error('msg="Failed to call Etherpad" method="%s" token="%s" response="%d: %s"' %
+                        (method, acctok[-20:] if acctok else 'N/A', res.status_code, res.content.decode()))
+            raise AppFailure
+    except requests.exceptions.ConnectionError as e:
+        log.error('msg="Exception raised attempting to connect to CodiMD" exception="%s"' % e)
         raise AppFailure
     res = res.json()
     if res['code'] != 0 and raiseonnonzerocode:
         log.error('msg="Error response from Etherpad" method="%s" token="%s" response="%s"' %
                     (method, acctok[-20:] if acctok else 'N/A', res['message']))
         raise AppFailure
+    log.debug('msg="Called Etherpad API" method="%s" token="%s" result="%s"' %
+              (method, acctok[-20:] if acctok else 'N/A', res))
     return res
 
 
@@ -96,22 +97,6 @@ def getredirecturl(isreadwrite, wopisrc, acctok, wopilock, displayname):
 # Cloud storage to Etherpad
 ###########################
 
-def _fetchfrometherpad(wopilock, acctok):
-    '''Fetch a given document from from Etherpad, raise AppFailure in case of errors'''
-    try:
-        # this request does not use the API, so we strip the `/api/1` part
-        res = requests.get(appurl + '/p/' + _padid(wopilock['docid'][1:]) + '/export/etherpad',
-                           verify=not skipsslverify)
-        if res.status_code != http.client.OK:
-            log.error('msg="Unable to fetch document from Etherpad" token="%s" response="%d: %s"' %
-                      (acctok[-20:], res.status_code, res.content.decode()))
-            raise AppFailure
-        return res.content
-    except requests.exceptions.ConnectionError as e:
-        log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
-        raise AppFailure
-
-
 def loadfromstorage(filemd, wopisrc, acctok, docid):
     '''Copy document from storage to Etherpad'''
     # WOPI GetFile
@@ -126,17 +111,20 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
         if not docid:
             docid = ''.join([choice(ascii_lowercase) for _ in range(20)])
             log.debug('msg="Generated random padID for read-only document" docid="%s" token="%s"' % (docid, acctok[-20:]))
-        # create pad with the given docid as name (the padID will be `groupid$docid`)
+        # first drop previous pad if it exists
+        res = _apicall('deletePad', {'padID': docid}, acctok=acctok, raiseonnonzerocode=False)
+        # create pad with the given docid as name
         res = _apicall('createGroupPad', {'groupID': groupid, 'padName': docid, 'text': 'placeholder'},
-                        acctok=acctok, raiseonnonzerocode=False)
+                       acctok=acctok, raiseonnonzerocode=False)
         log.debug('msg="Got pad" token="%s" docid="%s" response="%s"' % (acctok[-20:], docid, res))
         # push content
-        res = requests.post(appurl + '/p/' + _padid(docid) + '/import',
+        res = requests.post(appurl + '/p/' + docid + '/import',
                             files={'file': (docid + '.etherpad', epfile)},    # a .etherpad file is imported as raw (JSON) content
+                            params={'apikey': apikey},
                             verify=not skipsslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
-                        (acctok[-20:], res.status_code, res.content.decode()))
+                      (acctok[-20:], res.status_code, res.content.decode()))
             raise AppFailure
         log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
     except requests.exceptions.ConnectionError as e:
@@ -149,12 +137,28 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
 # Etherpad to cloud storage
 ###########################
 
+def _fetchfrometherpad(wopilock, acctok):
+    '''Fetch a given document from from Etherpad, raise AppFailure in case of errors'''
+    try:
+        # this operation does not use the API (and it is NOT protected by the API key!), so we use a plain GET
+        res = requests.get(appurl + '/p' + wopilock['docid'] + '/export/etherpad',
+                           verify=not skipsslverify)
+        if res.status_code != http.client.OK:
+            log.error('msg="Unable to fetch document from Etherpad" token="%s" response="%d: %s"' %
+                      (acctok[-20:], res.status_code, res.content.decode()))
+            raise AppFailure
+        return res.content
+    except requests.exceptions.ConnectionError as e:
+        log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
+        raise AppFailure
+
+
 def savetostorage(wopisrc, acctok, isclose, wopilock):
     '''Copy document from Etherpad back to storage'''
     # get document from Etherpad
     try:
         log.info('msg="Fetching file from Etherpad" isclose="%s" appurl="%s" token="%s"' %
-                 (isclose, appurl + '/p' + _padid(wopilock['docid'][1:]), acctok[-20:]))
+                 (isclose, appurl + '/p' + wopilock['docid'], acctok[-20:]))
         epfile = _fetchfrometherpad(wopilock, acctok)
     except AppFailure:
         return jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
@@ -162,7 +166,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     if wopilock['digest'] != 'dirty':
         # so far the file was not touched: before forcing a put let's validate the contents
         h = hashlib.sha1()
-        h.update(epfile.encode())
+        h.update(epfile)
         if h.hexdigest() == wopilock['digest']:
             log.info('msg="File unchanged, skipping save" token="%s"' % acctok[-20:])
             return '{}', http.client.ACCEPTED

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -8,6 +8,7 @@ Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 
 from random import choice
 from string import ascii_lowercase
+import time
 import json
 import hashlib
 import http.client
@@ -25,6 +26,7 @@ appexturl = None
 apikey = None
 log = None
 skipsslverify = None
+groupid = None
 
 
 def init(env, apipath):
@@ -32,6 +34,7 @@ def init(env, apipath):
     global appurl
     global appexturl
     global apikey
+    global groupid
     appexturl = env.get('ETHERPAD_EXT_URL')
     if not appexturl:
         raise ValueError("Missing ETHERPAD_EXT_URL env var")
@@ -39,9 +42,12 @@ def init(env, apipath):
     if not appurl:
         # defaults to the external
         appurl = appexturl
-    appurl += '/api/1'
     with open(apipath + 'etherpad_apikey') as f:
         apikey = f.readline().strip('\n')
+    # create a general group to attach all pads
+    groupid = _apicall('createGroupIfNotExistsFor', {'groupMapper': 1})
+    groupid = groupid['data']['groupID']
+    log.info('msg="Got Etherpad global groupid" groupid="%s"' % groupid)
 
 
 def jsonify(msg):
@@ -49,19 +55,42 @@ def jsonify(msg):
     return '{"message": "%s"}' % msg
 
 
+def _padid(padname):
+    '''One-liner to generate a padID from a padName'''
+    return groupid + '$' + padname
+
+
+def _apicall(method, params, data=None, acctok=None, raiseonnonzerocode=True):
+    '''Generic method to call the Etherpad REST API'''
+    params['apikey'] = apikey
+    res = requests.post(appurl + '/api/1/' + method, params=params, data=data, verify=not skipsslverify)
+    if res.status_code != http.client.OK:
+        log.error('msg="Failed to call Etherpad" method="%s" token="%s" response="%d: %s"' %
+                    (method, acctok[-20:] if acctok else 'N/A', res.status_code, res.content.decode()))
+        raise AppFailure
+    res = res.json()
+    if res['code'] != 0 and raiseonnonzerocode:
+        log.error('msg="Error response from Etherpad" method="%s" token="%s" response="%s"' %
+                    (method, acctok[-20:] if acctok else 'N/A', res['message']))
+        raise AppFailure
+    return res
+
+
 def getredirecturl(isreadwrite, wopisrc, acctok, wopilock, displayname):
     '''Return a valid URL to the app for the given WOPI context'''
-    if isreadwrite:
-        url = appexturl + '/p' + wopilock['docid'] + '?metadata=' + \
-              urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + '&'
-    else:
-        # read-only mode: first obtain a read-only link
-        # TODO /getReadOnly
-        url = appexturl # + res....
-    # set the displayname
-    # TODO /setUser
-    # return the URL with the API key
-    return url + 'apikey=' + apikey
+    if not isreadwrite:
+        # read-only mode: first generate a read-only link
+        res = _apicall('getReadOnlyID', {'padID': wopilock['docid'][1:]}, acctok=acctok)
+        return appexturl + '/p/' + res['data']['readOnlyID']
+    # associate the displayname to an author
+    res = _apicall('createAuthorIfNotExistsFor', {'name': displayname, 'authorMapper': displayname}, acctok=acctok)
+    authorid = res['data']['authorID']
+    # create session
+    validity = int(time.time() + 86400)
+    res = _apicall('createSession', {'groupID': groupid, 'authorID': authorid, 'validUntil': validity}, acctok=acctok)
+    # return an url to the auth_session plugin
+    return appexturl + '/auth_session?sessionID=' + res['data']['sessionID'] + '&padName=' + wopilock['docid'][1:] + \
+           '&metadata=' + urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok))
 
 
 # Cloud storage to Etherpad
@@ -70,11 +99,12 @@ def getredirecturl(isreadwrite, wopisrc, acctok, wopilock, displayname):
 def _fetchfrometherpad(wopilock, acctok):
     '''Fetch a given document from from Etherpad, raise AppFailure in case of errors'''
     try:
-        res = requests.get(appurl + '/p' + wopilock['docid'] + '/export/etherpad',
+        # this request does not use the API, so we strip the `/api/1` part
+        res = requests.get(appurl + '/p/' + _padid(wopilock['docid'][1:]) + '/export/etherpad',
                            verify=not skipsslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Unable to fetch document from Etherpad" token="%s" response="%d: %s"' %
-                      (acctok[-20:], res.status_code, res.content))
+                      (acctok[-20:], res.status_code, res.content.decode()))
             raise AppFailure
         return res.content
     except requests.exceptions.ConnectionError as e:
@@ -94,34 +124,21 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
     h.update(epfile)
     try:
         if not filemd['UserCanWrite']:
-            # read-only case: push the doc to a newly generated note with a random padid
             docid = ''.join([choice(ascii_lowercase) for _ in range(20)])
-            res = requests.post(appurl + '/createPad',
-                                data={'text': epfile},
-                                params={'apikey': apikey, 'padID': docid},
-                                verify=not skipsslverify)
-            if res.status_code != http.client.OK:
-                log.error('msg="Unable to push read-only document to Etherpad" token="%s" response="%d"' %
-                          (acctok[-20:], res.status_code))
-                raise AppFailure
-            log.info('msg="Pushed read-only document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
-        else:
-            # generate a deterministic note hash and use it in Etherpad
-            res = requests.post(appurl + '/createPad',
-                                data={'text': epfile},
-                                params={'apikey': apikey, 'padID': docid},
-                                verify=not skipsslverify)
-            if res.status_code != http.client.OK:
-                log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
-                          (acctok[-20:], res.status_code, res.content))
-                raise AppFailure
-            if res.json()['code'] == 1:
-                # already exists, update text
-                res = requests.post(appurl + '/setText',
-                                    data={'text': epfile},
-                                    params={'apikey': apikey, 'padID': docid},
-                                    verify=not skipsslverify)
-            log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
+            log.debug('msg="Generated random padID for read-only document" docid="%s" token="%s"' % (docid, acctok[-20:]))
+        # create pad with the given docid as name (the padID will be `groupid$docid`)
+        res = _apicall('createGroupPad', {'groupID': groupid, 'padName': docid, 'text': 'placeholder'},
+                        acctok=acctok, raiseonnonzerocode=False)
+        log.debug('msg="Got pad" token="%s" docid="%s" response="%s"' % (acctok[-20:], docid, res))
+        # push content
+        res = requests.post(appurl + '/p/' + _padid(docid) + '/import',
+                            files={'file': (docid + '.etherpad', epfile)},    # a .etherpad file is imported as raw (JSON) content
+                            verify=not skipsslverify)
+        if res.status_code != http.client.OK:
+            log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
+                        (acctok[-20:], res.status_code, res.content.decode()))
+            raise AppFailure
+        log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
         raise AppFailure
@@ -137,7 +154,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     # get document from Etherpad
     try:
         log.info('msg="Fetching file from Etherpad" isclose="%s" appurl="%s" token="%s"' %
-                 (isclose, appurl + wopilock['docid'], acctok[-20:]))
+                 (isclose, appurl + '/p' + _padid(wopilock['docid'][1:]), acctok[-20:]))
         epfile = _fetchfrometherpad(wopilock, acctok)
     except AppFailure:
         return jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -124,20 +124,6 @@ def loadfromstorage(filemd, wopisrc, acctok):
 # Etherpad to cloud storage
 ###########################
 
-def _dealwithputfile(wopicall, wopisrc, res):
-    '''Deal with conflicts or errors following a PutFile/PutRelative request'''
-    if res.status_code == http.client.CONFLICT:
-        log.warning('msg="Conflict when calling WOPI %s" url="%s" reason="%s"' %
-                    (wopicall, wopisrc, res.headers.get('X-WOPI-LockFailureReason')))
-        return jsonify('Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason')), \
-               http.client.INTERNAL_SERVER_ERROR
-    if res.status_code != http.client.OK:
-        log.error('msg="Calling WOPI %s failed" url="%s" response="%s"' % (wopicall, wopisrc, res.status_code))
-        # TODO need to save the file on a local storage for later recovery
-        return jsonify('Error saving the file, please contact support'), http.client.INTERNAL_SERVER_ERROR
-    return None
-
-
 def _saveas(wopisrc, acctok, wopilock, targetname, content):
     '''Save a given document with an alternate name by using WOPI PutRelative'''
     putrelheaders = {'X-WOPI-Lock': json.dumps(wopilock),
@@ -146,9 +132,9 @@ def _saveas(wopisrc, acctok, wopilock, targetname, content):
                      'X-WOPI-SuggestedTarget': targetname
                     }
     res = wopi.request(wopisrc, acctok, 'POST', headers=putrelheaders, contents=content)
-    reply = _dealwithputfile('PutRelative', wopisrc, res)
+    reply = wopi.handleputfile('PutRelative', wopisrc, res)
     if reply:
-        return reply
+        return jsonify(reply), http.client.INTERNAL_SERVER_ERROR
 
     # use the new file's metadata from PutRelative to remove the previous file: we can do that only on close
     # because we need to keep using the current wopisrc/acctok until the session is alive in Etherpad
@@ -197,9 +183,9 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     if True: # (wasbundle ^ (not bundlefile)) or not isclose:
         res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock)},
                            contents=mddoc)
-        reply = _dealwithputfile('PutFile', wopisrc, res)
+        reply = wopi.handleputfile('PutFile', wopisrc, res)
         if reply:
-            return reply
+            return jsonify(reply), http.client.INTERNAL_SERVER_ERROR
         wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
         log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
                  (wopilock['filename'], isclose, acctok[-20:]))

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -8,10 +8,8 @@ Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 
 from random import choice
 from string import ascii_lowercase
-import time
 import json
 import hashlib
-import hmac
 import http.client
 import urllib.parse as urlparse
 import requests
@@ -76,21 +74,10 @@ def _apicall(method, params, data=None, acctok=None, raiseonnonzerocode=True):
 def getredirecturl(isreadwrite, wopisrc, acctok, wopilock, displayname):
     '''Return a valid URL to the app for the given WOPI context'''
     if not isreadwrite:
-        # read-only mode: first generate a read-only link
+        # for read-only mode generate a read-only link
         res = _apicall('getReadOnlyID', {'padID': wopilock['docid'][1:]}, acctok=acctok)
         return appexturl + '/p/' + res['data']['readOnlyID']
-    # associate the displayname to an author
-    #authorid = hmac.new(apikey.encode(), displayname.encode(), digestmod=hashlib.sha1).digest()
-    #authorid = int.from_bytes(authorid[4:12], 'big')    # arbitrarily take 8 bytes = 64bit int
-    #res = _apicall('createAuthorIfNotExistsFor', {'name': displayname, 'authorMapper': authorid}, acctok=acctok)
-    #authorid = res['data']['authorID']
-    # create session
-    #validity = int(time.time() + 86400)
-    #res = _apicall('createSession', {'groupID': groupid, 'authorID': authorid, 'validUntil': validity}, acctok=acctok)
-    # return an url to the auth_session plugin
-    #return appexturl + '/auth_session?sessionID=%s&padName=%s&userName=%s&metadata=%s' % \
-    #       (res['data']['sessionID'], wopilock['docid'][1:], displayname, urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok))
-    # return an url to the pad
+    # return the URL to the pad (TODO the metadata argument must be picked up by an Etherpad plugin)
     return appexturl + '/p/%s?userName=%s&metadata=%s' % \
            (wopilock['docid'][1:], displayname, urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)))
 

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -33,12 +33,12 @@ def init(env, apipath):
     global appexturl
     global apikey
     appexturl = env.get('ETHERPAD_EXT_URL')
+    if not appexturl:
+        raise ValueError("Missing ETHERPAD_EXT_URL env var")
     appurl = env.get('ETHERPAD_URL')
     if not appurl:
         # defaults to the external
         appurl = appexturl
-    if not appurl:
-        raise ValueError("Missing ETHERPAD_EXT_URL env var")
     appurl += '/api/1'
     with open(apipath + 'etherpad_apikey') as f:
         apikey = f.readline().strip('\n')

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -1,0 +1,224 @@
+'''
+etherpad.py
+
+The Etherpad-specific code used by the WOPI bridge.
+
+Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+'''
+
+import os
+import re
+import zipfile
+import io
+from random import randint
+import json
+import hashlib
+import urllib.parse as urlparse
+import http.client
+from base64 import urlsafe_b64encode
+import hmac
+import requests
+import wopiclient as wopi
+
+
+class EtherpadFailure(Exception):
+    '''A custom exception to represent a fatal failure when contacting Etherpad'''
+
+# a regexp for uploads, that have links like '/uploads/upload_542a360ddefe1e21ad1b8c85207d9365.*'
+upload_re = re.compile(r'\/uploads\/upload_\w{32}\.\w+')
+
+# initialized by the main class
+log = None
+codimdurl = None
+codimdexturl = None
+skipsslverify = None
+hashsecret = None
+
+
+def jsonify(msg):
+    '''One-liner to consistently json-ify a given message'''
+    # a delay = 0 means the user has to click on it to dismiss it, good for longer messages
+    return '{"message": "%s", "delay": "%.1f"}' % (msg, 0 if len(msg) > 60 else 0.5 + len(msg)/20)
+
+
+# Cloud storage to Etherpad
+###########################
+
+
+def _fetchfrometherpad(wopilock, acctok):
+    '''Fetch a given document from from Etherpad, raise EtherpadFailure in case of errors'''
+    try:
+        res = requests.get(codimdurl + wopilock['docid'] + '/download', verify=not skipsslverify)
+        if res.status_code != http.client.OK:
+            log.error('msg="Unable to fetch document from Etherpad" token="%s" response="%d: %s"' %
+                      (acctok[-20:], res.status_code, res.content))
+            raise EtherpadFailure
+        return res.content
+    except requests.exceptions.ConnectionError as e:
+        log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
+        raise EtherpadFailure
+
+
+def checkredirect(wopilock, _acctok_unused):
+    '''Check if the target docid is real or is a redirect, and amend the wopilock structure in such case'''
+    return wopilock
+
+
+def loadfromstorage(filemd, wopisrc, acctok):
+    '''Copy document from storage to Etherpad'''
+    # WOPI GetFile
+    res = wopi.request(wopisrc, acctok, 'GET', contents=True)
+    if res.status_code != http.client.OK:
+        raise ValueError(res.status_code)
+    mdfile = res.content
+    #wasbundle = os.path.splitext(filemd['BaseFileName'])[1] == '.zmd'
+
+    # if it's a bundled file, unzip it and push the attachments in the appropriate folder
+    #if wasbundle:
+    #    mddoc = _unzipattachments(mdfile)
+    #else:
+    mddoc = mdfile
+    # compute its SHA1 hash for later checks if the file was modified
+    h = hashlib.sha1()
+    h.update(mddoc)
+    try:
+        if not filemd['UserCanWrite']:
+            # read-only case: push the doc to a newly generated note with a random docid
+            res = requests.post(codimdurl + '/new', data=mddoc,
+                                allow_redirects=False,
+                                params={'mode': 'locked'},
+                                headers={'Content-Type': 'text/markdown'},
+                                verify=not skipsslverify)
+            if res.status_code != http.client.FOUND:
+                log.error('msg="Unable to push read-only document to Etherpad" token="%s" response="%d"' %
+                          (acctok[-20:], res.status_code))
+                raise EtherpadFailure
+            notehash = urlparse.urlsplit(res.next.url).path.split('/')[-1]
+            log.info('msg="Pushed read-only document to Etherpad" docid="%s" token="%s"' % (notehash, acctok[-20:]))
+        else:
+            # generate a deterministic note hash and reserve it in Etherpad via a HEAD request
+            dig = hmac.new(hashsecret, msg=wopisrc.split('/')[-1].encode(), digestmod=hashlib.sha1).digest()
+            notehash = urlsafe_b64encode(dig).decode()[:-1]
+            res = requests.head(codimdurl + '/' + notehash,
+                                params={'apikey': hashlib.md5(hashsecret).hexdigest()},
+                                verify=not skipsslverify)
+            if res.status_code != http.client.OK:
+                log.error('msg="Unable to reserve note hash in Etherpad" token="%s" response="%d"' %
+                          (acctok[-20:], res.status_code))
+                raise EtherpadFailure
+            log.debug('msg="Got note hash from Etherpad" docid="%s"' % notehash)
+            # push the document to Etherpad with the update API
+            # TODO in the future we could swap the logic: attempt to push content, and on 404 use a HEAD
+            # request to reserve the notehash + do the push again. In most cases the note will be there
+            # thus we would avoid the HEAD call.
+            res = requests.put(codimdurl + '/api/notes/' + notehash,
+                               params={'apikey': hashlib.md5(hashsecret).hexdigest()},    # possibly required in the future
+                               json={'content': mddoc.decode()},
+                               verify=not skipsslverify)
+            if res.status_code == http.client.FORBIDDEN:
+                # the file got unlocked because of no activity, yet some user is there: let it go
+                log.warning('msg="Document was being edited in Etherpad, redirecting user" token"%s"' % acctok[-20:])
+            elif res.status_code != http.client.OK:
+                log.error('msg="Unable to push document to Etherpad" token="%s" response="%d"' %
+                          (acctok[-20:], res.status_code))
+                raise EtherpadFailure
+            else:
+                log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (notehash, acctok[-20:]))
+    except requests.exceptions.ConnectionError as e:
+        log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
+        raise EtherpadFailure
+    # we got the hash of the document just created as a redirected URL, generate a WOPI lock structure
+    wopilock = wopi.generatelock(notehash, filemd, h.hexdigest(),
+                                 'etherpad',
+                                 acctok, False)
+    return wopilock
+
+
+# Etherpad to cloud storage
+###########################
+
+def _dealwithputfile(wopicall, wopisrc, res):
+    '''Deal with conflicts or errors following a PutFile/PutRelative request'''
+    if res.status_code == http.client.CONFLICT:
+        log.warning('msg="Conflict when calling WOPI %s" url="%s" reason="%s"' %
+                    (wopicall, wopisrc, res.headers.get('X-WOPI-LockFailureReason')))
+        return jsonify('Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason')), \
+               http.client.INTERNAL_SERVER_ERROR
+    if res.status_code != http.client.OK:
+        log.error('msg="Calling WOPI %s failed" url="%s" response="%s"' % (wopicall, wopisrc, res.status_code))
+        # TODO need to save the file on a local storage for later recovery
+        return jsonify('Error saving the file, please contact support'), http.client.INTERNAL_SERVER_ERROR
+    return None
+
+
+def _saveas(wopisrc, acctok, wopilock, targetname, content):
+    '''Save a given document with an alternate name by using WOPI PutRelative'''
+    putrelheaders = {'X-WOPI-Lock': json.dumps(wopilock),
+                     'X-WOPI-Override': 'PUT_RELATIVE',
+                     # SuggestedTarget to not overwrite a possibly existing file
+                     'X-WOPI-SuggestedTarget': targetname
+                    }
+    res = wopi.request(wopisrc, acctok, 'POST', headers=putrelheaders, contents=content)
+    reply = _dealwithputfile('PutRelative', wopisrc, res)
+    if reply:
+        return reply
+
+    # use the new file's metadata from PutRelative to remove the previous file: we can do that only on close
+    # because we need to keep using the current wopisrc/acctok until the session is alive in Etherpad
+    newname = res.json()['Name']
+    # unlock and delete original file
+    res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock), 'X-Wopi-Override': 'UNLOCK'})
+    if res.status_code != http.client.OK:
+        log.warning('msg="Failed to unlock the previous file" token="%s" response="%d"' %
+                    (acctok[-20:], res.status_code))
+    else:
+        res = wopi.request(wopisrc, acctok, 'POST', headers={'X-Wopi-Override': 'DELETE'})
+        if res.status_code != http.client.OK:
+            log.warning('msg="Failed to delete the previous file" token="%s" response="%d"' %
+                        (acctok[-20:], res.status_code))
+        else:
+            log.info('msg="Previous file unlocked and removed successfully" token="%s"' % acctok[-20:])
+
+    log.info('msg="Final save completed" filename"%s" token="%s"' % (newname, acctok[-20:]))
+    return jsonify('File saved successfully'), http.client.OK
+
+
+def savetostorage(wopisrc, acctok, isclose, wopilock):
+    '''Copy document from Etherpad back to storage'''
+    # get document from Etherpad
+    try:
+        log.info('msg="Fetching file from Etherpad" isclose="%s" codimdurl="%s" token="%s"' %
+                 (isclose, codimdurl + wopilock['docid'], acctok[-20:]))
+        mddoc = _fetchfrometherpad(wopilock, acctok)
+    except EtherpadFailure:
+        return jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
+
+    if wopilock['digest'] != 'dirty':
+        # so far the file was not touched: before forcing a put let's validate the contents
+        h = hashlib.sha1()
+        h.update(mddoc)
+        if h.hexdigest() == wopilock['digest']:
+            log.info('msg="File unchanged, skipping save" token="%s"' % acctok[-20:])
+            return '{}', http.client.ACCEPTED
+
+    # check if we have attachments
+    # wasbundle = os.path.splitext(wopilock['filename'])[1] == '.zmd'
+    # bundlefile, attresponse = _getattachments(mddoc.decode(), wopilock['filename'].replace('.zmd', '.md'),
+    #                                          (wasbundle and not isclose))
+
+    # WOPI PutFile for the file or the bundle if it already existed
+    if True: # (wasbundle ^ (not bundlefile)) or not isclose:
+        res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock)},
+                           contents=mddoc)
+        reply = _dealwithputfile('PutFile', wopisrc, res)
+        if reply:
+            return reply
+        wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
+        log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
+                 (wopilock['filename'], isclose, acctok[-20:]))
+        # combine the responses
+        return jsonify('File saved successfully'), http.client.OK
+
+    # on close, use saveas for either the new bundle, if this is the first time we have attachments,
+    # or the single md file, if there are no more attachments.
+    return _saveas(wopisrc, acctok, wopilock, wopilock['filename'], mddoc)

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -50,11 +50,6 @@ def init(env, apipath):
     log.info('msg="Got Etherpad global groupid" groupid="%s"' % groupid)
 
 
-def jsonify(msg):
-    '''One-liner to consistently json-ify a given message'''
-    return '{"message": "%s"}' % msg
-
-
 def _apicall(method, params, data=None, acctok=None, raiseonnonzerocode=True):
     '''Generic method to call the Etherpad REST API'''
     params['apikey'] = apikey
@@ -161,7 +156,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
                  (isclose, appurl + '/p' + wopilock['docid'], acctok[-20:]))
         epfile = _fetchfrometherpad(wopilock, acctok)
     except AppFailure:
-        return jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
+        return wopi.jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
 
     if wopilock['digest'] != 'dirty':
         # so far the file was not touched: before forcing a put let's validate the contents
@@ -176,8 +171,8 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
                         contents=epfile)
     reply = wopi.handleputfile('PutFile', wopisrc, res)
     if reply:
-        return jsonify(reply), http.client.INTERNAL_SERVER_ERROR
+        return reply
     wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
     log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
                 (wopilock['filename'], isclose, acctok[-20:]))
-    return jsonify('File saved successfully'), http.client.OK
+    return wopi.jsonify('File saved successfully'), http.client.OK

--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -123,7 +123,7 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
     h = hashlib.sha1()
     h.update(epfile)
     try:
-        if not filemd['UserCanWrite']:
+        if not docid:
             docid = ''.join([choice(ascii_lowercase) for _ in range(20)])
             log.debug('msg="Generated random padID for read-only document" docid="%s" token="%s"' % (docid, acctok[-20:]))
         # create pad with the given docid as name (the padID will be `groupid$docid`)

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -113,8 +113,10 @@ class WB:
                     cls.plugins[p].init(os.environ, APIKEYPATH)
                     cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
                 except Exception as e:
-                    cls.log.info('msg="App plugin disabled because initialization failed" app="%s" message="%s"' % (p, e))
+                    cls.log.info('msg="Disabled plugin following failed initialization" app="%s" message="%s"' % (p, e))
                     cls.plugins[p] = None
+            if not list(filter(None.__ne__, cls.plugins.values())):
+                raise ValueError('None of the available app plugins could be initialized')
 
             # start the thread to perform async save operations
             cls.savethread = SaveThread()

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -256,8 +256,8 @@ def appopen():
             except KeyError:
                 pass
         else:
-            # user has no write privileges, just fetch document and push it to the app
-            wopilock = app.loadfromstorage(filemd, wopisrc, acctok, _gendocid(wopisrc))
+            # user has no write privileges, just fetch the document and push it to the app on a random docid
+            wopilock = app.loadfromstorage(filemd, wopisrc, acctok, None)
     except app.AppFailure:
         # this can be raised by loadfromstorage
         return _guireturn('Unable to load the app, please try again later or contact support'), http.client.INTERNAL_SERVER_ERROR

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -161,7 +161,7 @@ def handleexception(ex):
     ex_type, ex_value, ex_traceback = sys.exc_info()
     WB.log.error('msg="Unexpected exception caught" exception="%s" type="%s" traceback="%s"' %
                  (ex, ex_type, traceback.format_exception(ex_type, ex_value, ex_traceback)))
-    return WB.plugins['codimd'].jsonify('Internal error, please contact support. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
+    return wopi.jsonify('Internal error, please contact support. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
 
 
 @WB.app.route("/", methods=['GET'])
@@ -287,7 +287,7 @@ def appsave():
     except (KeyError, ValueError) as e:
         WB.log.error('msg="Save: malformed or missing metadata" client="%s" headers="%s" exception="%s" error="%s"' %
                      (flask.request.remote_addr, flask.request.headers, type(e), e))
-        return WB.plugins['codimd'].jsonify('Malformed or missing metadata, could not save. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
+        return wopi.jsonify('Malformed or missing metadata, could not save. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
 
     # decide whether to notify the save thread
     donotify = isclose or wopisrc not in WB.openfiles or WB.openfiles[wopisrc]['lastsave'] < time.time() - WB.saveinterval
@@ -383,7 +383,7 @@ class SaveThread(threading.Thread):
                 except wopi.InvalidLock as ile:
                     # even this attempt failed, give up
                     # TODO here we should save the file on a local storage to help later recovery
-                    WB.saveresponses[wopisrc] = WB.plugins['codimd'].jsonify(str(ile)), http.client.INTERNAL_SERVER_ERROR
+                    WB.saveresponses[wopisrc] = wopi.jsonify(str(ile)), http.client.INTERNAL_SERVER_ERROR
                     # set some 'fake' metadata, will be automatically cleaned up later
                     openfile['lastsave'] = int(time.time())
                     openfile['tosave'] = False
@@ -392,7 +392,7 @@ class SaveThread(threading.Thread):
             app = BRIDGE_EXT_PLUGINS.get(wopilock['app'])
             if not app:
                 WB.log.error('msg="SaveThread: malformed app attribute in WOPI lock" lock="%s"' % wopilock)
-                WB.saveresponses[wopisrc] = WB.plugins['codimd'].jsonify('Unrecognized app for this file'), http.client.BAD_REQUEST
+                WB.saveresponses[wopisrc] = wopi.jsonify('Unrecognized app for this file'), http.client.BAD_REQUEST
             else:
                 WB.log.info('msg="SaveThread: saving file" token="%s" docid="%s"' %
                             (openfile['acctok'][-20:], openfile['docid']))

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -2,8 +2,7 @@
 '''
 wopibridge.py
 
-The WOPI bridge for IOP. This PoC only integrates CodiMD
-and for now the code is not fully abstracted to support other integrations.
+The WOPI Bridge for IOP. This connector service supports CodiMD and Etherpad.
 
 Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
@@ -22,6 +21,8 @@ import urllib.parse as urlparse
 import http.client
 import json
 import hashlib
+import hmac
+from base64 import urlsafe_b64encode
 try:
     import flask
     from werkzeug.exceptions import NotFound as Flask_NotFound
@@ -30,7 +31,6 @@ except ImportError:
     print("Missing modules, please install with `pip3 install flask requests`")
     raise
 import wopiclient as wopi
-import etherpad
 
 WBVERSION = 'git'
 
@@ -43,15 +43,17 @@ SECRETPATH = '/var/run/secrets/wbsecret'
 # path to the APIKEY secrets
 APIKEYPATH = '/var/run/secrets/'
 
+# The supported plugins integrated with this WOPI Bridge
+BRIDGE_EXT_PLUGINS = {'md': 'codimd', 'zmd': 'codimd', 'mds': 'codimd', 'epd': 'etherpad'}
+
 # a standard message to be displayed by the app when some content might be lost: this would only
-# appear in case of uncaught exceptions or bugs handling the CodiMD webhook
+# appear in case of uncaught exceptions or bugs handling the webhook callbacks
 RECOVER_MSG = 'Please copy the content to a safe place and reopen the document again to paste it back.'
 
 
 class WB:
     '''A singleton container for all state information of the server'''
-    approot = os.getenv(
-        'APP_ROOT', '/wopib')               # application root path
+    approot = os.getenv('APP_ROOT', '/wopib')               # application root path
     bpr = flask.Blueprint('WOPIBridge', __name__, url_prefix=approot)
     app = flask.Flask('WOPIBridge')
     log = app.logger
@@ -71,6 +73,8 @@ class WB:
     saveresponses = {}  # a map of responses: wopisrc -> (http code, message)
     # a condition variable to synchronize the save thread and the main Flask threads
     savecv = threading.Condition()
+    # a map file-extension -> application plugin
+    plugins = {}
 
     @classmethod
     def init(cls):
@@ -83,21 +87,11 @@ class WB:
                                                       datefmt='%Y-%m-%dT%H:%M:%S'))
             cls.log.addHandler(loghandler)
             cls.log.setLevel(cls.loglevels['Debug'])
-            # this is the external-facing URL
-            etherpad.codimdexturl = os.environ.get('CODIMD_EXT_URL')
-            # this is the internal URL (e.g. as visible in docker/K8s)
-            etherpad.codimdurl = os.environ.get('CODIMD_INT_URL') + '/api/1'
             skipsslverify = os.environ.get('SKIP_SSL_VERIFY')
             if isinstance(skipsslverify, str):
                 cls.skipsslverify = skipsslverify.upper() in ('TRUE', 'YES')
             else:
                 cls.skipsslverify = False
-            if not etherpad.codimdurl:
-                # defaults to the external
-                etherpad.codimdurl = etherpad.codimdexturl + '/api/1'
-            if not etherpad.codimdurl:
-                # this is the only mandatory option
-                raise ValueError("Missing CODIMD_EXT_URL configuration")
             try:
                 cls.saveinterval = int(os.environ.get('APP_SAVE_INTERVAL'))
             except TypeError:
@@ -106,11 +100,17 @@ class WB:
                 cls.saveinterval = int(os.environ.get('APP_UNLOCK_INTERVAL'))
             except TypeError:
                 cls.unlockinterval = 90
-            # init modules
-            etherpad.log = wopi.log = cls.log
-            etherpad.skipsslverify = wopi.skipsslverify = cls.skipsslverify
             with open(SECRETPATH) as f:
                 cls.hashsecret = f.readline().strip('\n')
+            wopi.log = cls.log
+            wopi.skipsslverify = cls.skipsslverify
+            # init plugins
+            for p in set(BRIDGE_EXT_PLUGINS.values()):
+                cls.plugins[p] = __import__(p, globals(), locals())
+                cls.plugins[p].init(os.environ, APIKEYPATH)
+                cls.plugins[p].log = cls.log
+                cls.plugins[p].skipsslverify = cls.skipsslverify
+                cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
 
             # start the thread to perform async save operations
             cls.savethread = SaveThread()
@@ -127,10 +127,10 @@ class WB:
            Secure https mode typically is to be provided by the infrastructure (k8s ingress, nginx...)'''
         if os.path.isfile(CERTPATH):
             cls.log.info('msg="WOPI Bridge starting in secure mode" baseUrl="%s" version="%s"' % (cls.approot, WBVERSION))
-            cls.app.run(host='0.0.0.0', port=cls.port, threaded=True, debug=True,
+            cls.app.run(host='0.0.0.0', port=cls.port, threaded=True,
                         ssl_context=(CERTPATH, CERTPATH.replace('cert', 'key')))
         else:
-            cls.log.info('msg="WOPI Bridge starting in unsecure mode" baseUrl="%s" version="%s"' % (cls.approot, WBVERSION))
+            cls.log.info('msg="WOPI Bridge starting in unsecure/debugging mode" baseUrl="%s" version="%s"' % (cls.approot, WBVERSION))
             cls.app.run(host='0.0.0.0', port=cls.port, threaded=True, debug=True)
 
 
@@ -139,49 +139,10 @@ def _guireturn(msg):
     return '<div align="center" style="color:#808080; padding-top:50px; font-family:Verdana">%s</div>' % msg
 
 
-def _renderagent(ua):
-    '''One-liner to render a user_agent struct in a user-friendly way'''
-    return ua.platform[:3] if ua.platform else 'oth'   # we could use ua.browser as well, but it's maybe not useful
-
-
-def _redirecttoapp(isreadwrite, wopisrc, acctok, wopilock):
-    '''Updates internal metadata and returns the correct redirect URL to the editor'''
-    if isreadwrite:
-        # need to check again if the actual target is elsewhere and we were redirected
-        # (this is CodiMD-specific and it is not understood why it happens in the first place; seems related to the update API)
-        wopilock = etherpad.checkredirect(wopilock, acctok)
-        # keep track of this open document for the save thread and for statistical purposes
-        if wopisrc in WB.openfiles:
-            # use the new acctok and the new/current wopilock content
-            WB.openfiles[wopisrc]['acctok'] = acctok
-            WB.openfiles[wopisrc]['toclose'] = wopilock['toclose']
-        else:
-            WB.openfiles[wopisrc] = {'acctok': acctok, 'tosave': False,
-                                     'lastsave': int(time.time()) - WB.saveinterval,
-                                     'toclose': {acctok[-20:]: False},
-                                     'docid': wopilock['docid'],
-                                    }
-        # also clear any potential stale response for this document
-        try:
-            del WB.saveresponses[wopisrc]
-        except KeyError:
-            pass
-        # create the external redirect URL to be returned to the client:
-        # metadata will be used for autosave (this is an extended feature of CodiMD)
-        redirecturl = etherpad.codimdexturl + '/p' + wopilock['docid'] + '?metadata=' + \
-                      urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + '&'
-    else:
-        # read-only mode: in this case redirect to publish mode or normal view
-        # to quickly jump in slide mode depending on the content
-        redirecturl = etherpad.codimdexturl + '/p' + wopilock['docid'] + \
-                      ('/publish?' if wopilock['app'] != 'slide' else '?')
-<<<<<<< HEAD
-    # in all cases append the API key
-    return redirecturl + 'apikey=' + plugins[].apikey + '&'
-=======
-    # in all cases append the MD5 hash of our secret as shared API key
-    return redirecturl + 'apikey=' + etherpad.hashsecret.decode() + '&'
->>>>>>> Minimal implementation of the Etherpad API
+def _gendocid(wopisrc):
+    '''Generate a URL safe hash of the wopisrc to be used as document id by the app'''
+    dig = hmac.new(WB.hashsecret.encode(), msg=wopisrc.split('/')[-1].encode(), digestmod=hashlib.sha1).digest()
+    return urlsafe_b64encode(dig).decode()[:-1]
 
 
 
@@ -196,7 +157,7 @@ def handleexception(ex):
     ex_type, ex_value, ex_traceback = sys.exc_info()
     WB.log.error('msg="Unexpected exception caught" exception="%s" type="%s" traceback="%s"' %
                  (ex, ex_type, traceback.format_exception(ex_type, ex_value, ex_traceback)))
-    return etherpad.jsonify('Internal error, please contact support. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
+    return WB.plugins['codimd'].jsonify('Internal error, please contact support. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
 
 
 @WB.app.route("/", methods=['GET'])
@@ -213,7 +174,7 @@ def index():
     <html><head><title>ScienceMesh WOPI Bridge</title></head>
     <body>
     <div align="center" style="color:#000080; padding-top:50px; font-family:Verdana; size:11">
-    This is a WOPI HTTP bridge, to be used in conjunction with a WOPI-enabled EFSS.<br>Only CodiMD is supported for now.<br>
+    This is a WOPI HTTP bridge, to be used in conjunction with a WOPI-enabled EFSS.<br>Supports CodiMD and Etherpad.<br>
     To use this service, please log in to your EFSS Storage and click on a supported document.</div>
     <div style="position: absolute; bottom: 10px; left: 10px; width: 99%%;"><hr>
     <i>ScienceMesh WOPI Bridge %s at %s. Powered by Flask %s for Python %s</i>.</div>
@@ -240,6 +201,11 @@ def appopen():
         WB.log.warning('msg="Open: unable to fetch file WOPI metadata" response="%d"' % res.status_code)
         return _guireturn('Invalid WOPI context'), http.client.NOT_FOUND
     filemd = res.json()
+    app = BRIDGE_EXT_PLUGINS.get(os.path.splitext(filemd['BaseFileName'])[1][1:])
+    if not app:
+        WB.log.warning('msg="Open: file type not supported" filename="%s" token="%s"' % (filemd['FileName'], acctok[-20:]))
+        return _guireturn('File type not supported'), http.client.BAD_REQUEST
+    app = WB.plugins[app]
 
     try:
         # use the 'UserCanWrite' attribute to decide whether the file is to be opened in read-only mode
@@ -258,7 +224,7 @@ def appopen():
                     filemd['UserCanWrite'] = False
 
                 # otherwise, this is the first user opening the file; in both cases, fetch it
-                wopilock = etherpad.loadfromstorage(filemd, wopisrc, acctok)
+                wopilock = app.loadfromstorage(filemd, wopisrc, acctok, _gendocid(wopisrc))
                 # and WOPI Lock it
                 res = wopi.request(wopisrc, acctok, 'POST', headers={'X-WOPI-Lock': json.dumps(wopilock),
                                                                      'X-Wopi-Override': 'LOCK'})
@@ -268,19 +234,36 @@ def appopen():
                                    (res.status_code, acctok[-20:]))
                     filemd['UserCanWrite'] = False
 
+            # keep track of this open document for the save thread and for statistical purposes
+            if wopisrc in WB.openfiles:
+                # use the new acctok and the new/current wopilock content
+                WB.openfiles[wopisrc]['acctok'] = acctok
+                WB.openfiles[wopisrc]['toclose'] = wopilock['toclose']
+            else:
+                WB.openfiles[wopisrc] = {'acctok': acctok, 'tosave': False,
+                                        'lastsave': int(time.time()) - WB.saveinterval,
+                                        'toclose': {acctok[-20:]: False},
+                                        'docid': wopilock['docid'],
+                                        }
+            # also clear any potential stale response for this document
+            try:
+                del WB.saveresponses[wopisrc]
+            except KeyError:
+                pass
         else:
-            # user has no write privileges, just fetch document and push it to CodiMD
-            wopilock = etherpad.loadfromstorage(filemd, wopisrc, acctok)
-    except etherpad.EtherpadFailure:
+            # user has no write privileges, just fetch document and push it to the app
+            wopilock = app.loadfromstorage(filemd, wopisrc, acctok, _gendocid(wopisrc))
+    except app.AppFailure:
         # this can be raised by loadfromstorage
-        return _guireturn('Unable to connect to CodiMD, please try again later or contact support'), http.client.INTERNAL_SERVER_ERROR
+        return _guireturn('Unable to load the app, please try again later or contact support'), http.client.INTERNAL_SERVER_ERROR
 
     # here we append the user browser to the displayName
     # TODO need to review this for production usage, it should actually come from WOPI if configured accordingly
-    redirecturl = _redirecttoapp(filemd['UserCanWrite'], wopisrc, acctok, wopilock) + \
-                  'displayName=' + urlparse.quote_plus(filemd['UserFriendlyName'] + \
-                  '@' + _renderagent(flask.request.user_agent))
-    WB.log.info('msg="Redirecting client to CodiMD" redirecturl="%s"' % redirecturl)
+    redirecturl = app.getredirecturl(
+            filemd['UserCanWrite'], wopisrc, acctok, wopilock,
+            urlparse.quote_plus(filemd['UserFriendlyName'] + '@' + \
+                                (flask.request.user_agent.platform[:3] if flask.request.user_agent.platform else 'oth')))
+    WB.log.info('msg="Redirecting client to the app" redirecturl="%s"' % redirecturl)
     return flask.redirect(redirecturl)
 
 
@@ -299,7 +282,7 @@ def appsave():
     except (KeyError, ValueError) as e:
         WB.log.error('msg="Save: malformed or missing metadata" client="%s" headers="%s" exception="%s" error="%s"' %
                      (flask.request.remote_addr, flask.request.headers, type(e), e))
-        return etherpad.jsonify('Malformed or missing metadata, could not save. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
+        return WB.plugins['codimd'].jsonify('Malformed or missing metadata, could not save. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR
 
     # decide whether to notify the save thread
     donotify = isclose or wopisrc not in WB.openfiles or WB.openfiles[wopisrc]['lastsave'] < time.time() - WB.saveinterval
@@ -395,18 +378,23 @@ class SaveThread(threading.Thread):
                 except wopi.InvalidLock as ile:
                     # even this attempt failed, give up
                     # TODO here we should save the file on a local storage to help later recovery
-                    WB.saveresponses[wopisrc] = etherpad.jsonify(str(ile)), http.client.INTERNAL_SERVER_ERROR
+                    WB.saveresponses[wopisrc] = WB.plugins['codimd'].jsonify(str(ile)), http.client.INTERNAL_SERVER_ERROR
                     # set some 'fake' metadata, will be automatically cleaned up later
                     openfile['lastsave'] = int(time.time())
                     openfile['tosave'] = False
                     openfile['toclose'] = {'invalid-lock': True}
                     return None
-            WB.log.info('msg="SaveThread: saving file" token="%s" docid="%s"' %
-                        (openfile['acctok'][-20:], openfile['docid']))
-            WB.saveresponses[wopisrc] = etherpad.savetostorage(
-                wopisrc, openfile['acctok'], _intersection(openfile['toclose']), wopilock)
-            openfile['lastsave'] = int(time.time())
-            openfile['tosave'] = False
+            app = BRIDGE_EXT_PLUGINS.get(wopilock['app'])
+            if not app:
+                WB.log.error('msg="SaveThread: malformed app attribute in WOPI lock" lock="%s"' % wopilock)
+                WB.saveresponses[wopisrc] = WB.plugins['codimd'].jsonify('Unrecognized app for this file'), http.client.BAD_REQUEST
+            else:
+                WB.log.info('msg="SaveThread: saving file" token="%s" docid="%s"' %
+                            (openfile['acctok'][-20:], openfile['docid']))
+                WB.saveresponses[wopisrc] = WB.plugins[app].savetostorage(
+                    wopisrc, openfile['acctok'], _intersection(openfile['toclose']), wopilock)
+                openfile['lastsave'] = int(time.time())
+                openfile['tosave'] = False
         return wopilock
 
     def closewhenidle(self, openfile, wopisrc, wopilock):

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -106,11 +106,15 @@ class WB:
             wopi.skipsslverify = cls.skipsslverify
             # init plugins
             for p in set(BRIDGE_EXT_PLUGINS.values()):
-                cls.plugins[p] = __import__(p, globals(), locals())
-                cls.plugins[p].init(os.environ, APIKEYPATH)
-                cls.plugins[p].log = cls.log
-                cls.plugins[p].skipsslverify = cls.skipsslverify
-                cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
+                try:
+                    cls.plugins[p] = __import__(p, globals(), locals())
+                    cls.plugins[p].init(os.environ, APIKEYPATH)
+                    cls.plugins[p].log = cls.log
+                    cls.plugins[p].skipsslverify = cls.skipsslverify
+                    cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
+                except Exception as e:
+                    cls.log.info('msg="App plugin disabled because initialization failed" app="%s" message="%s"' % (p, e))
+                    cls.plugins[p] = None
 
             # start the thread to perform async save operations
             cls.savethread = SaveThread()
@@ -119,7 +123,7 @@ class WB:
         except Exception as e:    # pylint: disable=broad-except
             # any error we get here with the configuration is fatal
             cls.log.fatal('msg="Failed to initialize the service, aborting" error="%s"' % e)
-            sys.exit(-22)
+            sys.exit(22)
 
     @classmethod
     def run(cls):

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -86,7 +86,7 @@ class WB:
             # this is the external-facing URL
             etherpad.codimdexturl = os.environ.get('CODIMD_EXT_URL')
             # this is the internal URL (e.g. as visible in docker/K8s)
-            etherpad.codimdurl = os.environ.get('CODIMD_INT_URL')
+            etherpad.codimdurl = os.environ.get('CODIMD_INT_URL') + '/api/1'
             skipsslverify = os.environ.get('SKIP_SSL_VERIFY')
             if isinstance(skipsslverify, str):
                 cls.skipsslverify = skipsslverify.upper() in ('TRUE', 'YES')
@@ -94,7 +94,7 @@ class WB:
                 cls.skipsslverify = False
             if not etherpad.codimdurl:
                 # defaults to the external
-                etherpad.codimdurl = etherpad.codimdexturl
+                etherpad.codimdurl = etherpad.codimdexturl + '/api/1'
             if not etherpad.codimdurl:
                 # this is the only mandatory option
                 raise ValueError("Missing CODIMD_EXT_URL configuration")
@@ -168,15 +168,20 @@ def _redirecttoapp(isreadwrite, wopisrc, acctok, wopilock):
             pass
         # create the external redirect URL to be returned to the client:
         # metadata will be used for autosave (this is an extended feature of CodiMD)
-        redirecturl = etherpad.codimdexturl + wopilock['docid'] + '?metadata=' + \
+        redirecturl = etherpad.codimdexturl + '/p' + wopilock['docid'] + '?metadata=' + \
                       urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + '&'
     else:
         # read-only mode: in this case redirect to publish mode or normal view
         # to quickly jump in slide mode depending on the content
-        redirecturl = etherpad.codimdexturl + wopilock['docid'] + \
+        redirecturl = etherpad.codimdexturl + '/p' + wopilock['docid'] + \
                       ('/publish?' if wopilock['app'] != 'slide' else '?')
+<<<<<<< HEAD
     # in all cases append the API key
     return redirecturl + 'apikey=' + plugins[].apikey + '&'
+=======
+    # in all cases append the MD5 hash of our secret as shared API key
+    return redirecturl + 'apikey=' + etherpad.hashsecret.decode() + '&'
+>>>>>>> Minimal implementation of the Etherpad API
 
 
 

--- a/poc_src/wopibridge.py
+++ b/poc_src/wopibridge.py
@@ -108,9 +108,9 @@ class WB:
             for p in set(BRIDGE_EXT_PLUGINS.values()):
                 try:
                     cls.plugins[p] = __import__(p, globals(), locals())
-                    cls.plugins[p].init(os.environ, APIKEYPATH)
                     cls.plugins[p].log = cls.log
                     cls.plugins[p].skipsslverify = cls.skipsslverify
+                    cls.plugins[p].init(os.environ, APIKEYPATH)
                     cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
                 except Exception as e:
                     cls.log.info('msg="App plugin disabled because initialization failed" app="%s" message="%s"' % (p, e))
@@ -209,6 +209,7 @@ def appopen():
     if not app:
         WB.log.warning('msg="Open: file type not supported" filename="%s" token="%s"' % (filemd['FileName'], acctok[-20:]))
         return _guireturn('File type not supported'), http.client.BAD_REQUEST
+    WB.log.debug('msg="Processing open for supported app" app="%s" plugin="%s"' % (app, WB.plugins[app]))
     app = WB.plugins[app]
 
     try:

--- a/poc_src/wopiclient.py
+++ b/poc_src/wopiclient.py
@@ -126,3 +126,15 @@ def relock(wopisrc, acctok, docid, isclose):
     # relock was successful, return lock: along with noteids univocally associated to files (WOPISrc's),
     # we are sure no other updates could have been missed
     return wopilock
+
+def handleputfile(wopicall, wopisrc, res):
+    '''Deal with conflicts or errors following a PutFile/PutRelative request'''
+    if res.status_code == http.client.CONFLICT:
+        log.warning('msg="Conflict when calling WOPI %s" url="%s" reason="%s"' %
+                    (wopicall, wopisrc, res.headers.get('X-WOPI-LockFailureReason')))
+        return 'Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason'))
+    if res.status_code != http.client.OK:
+        log.error('msg="Calling WOPI %s failed" url="%s" response="%s"' % (wopicall, wopisrc, res.status_code))
+        # TODO need to save the file on a local storage for later recovery
+        return 'Error saving the file, please contact support'
+    return None


### PR DESCRIPTION
This large PR refactors the code to enable generic support for apps that can be integrated with the same principles as CodiMD. 

Furthermore, it implements some initial support for Etherpad, though it is not yet integrated at the same level as CodiMD.
