### PR TITLE
Compute checksum on close for CodiMD

### DIFF
--- a/poc_src/etherpad.py
+++ b/poc_src/etherpad.py
@@ -150,7 +150,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     except AppFailure:
         return wopi.jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
 
-    if wopilock['digest'] != 'dirty':
+    if isclose and wopilock['digest'] != 'dirty':
         # so far the file was not touched: before forcing a put let's validate the contents
         h = hashlib.sha1()
         h.update(epfile)
@@ -164,7 +164,7 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     reply = wopi.handleputfile('PutFile', wopisrc, res)
     if reply:
         return reply
-    wopi.refreshlock(wopisrc, acctok, wopilock, isdirty=True)
+    wopilock = wopi.refreshlock(wopisrc, acctok, wopilock, digest='dirty')
     log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
-                (wopilock['filename'], isclose, acctok[-20:]))
+             (wopilock['filename'], isclose, acctok[-20:]))
     return wopi.jsonify('File saved successfully'), http.client.OK


### PR DESCRIPTION
CodiMD has been observed to repeatedly send a heartbeat notification when a document is left open, even if there are no modifications. These are dutifully sent back to the wopibridge, which saves the file over and over again. See [CERNBOX-2000](https://its.cern.ch/jira/browse/CERNBOX-2000) for more details.

This PR fixes this problem by recomputing the checksum of the file on close, as it is done on open, and updating the lock such that any following save event is skipped if the content does not change further.